### PR TITLE
Feature Recent / Queue List

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -43,8 +43,6 @@ function fetchSongs(userSearch) {
                 response.json().then(function (data) {
                     displaySongs(data);
                     songData = data;
-                    console.log(songData);
-
                 });
             }
         })
@@ -246,7 +244,7 @@ function renderRecentList() {
     }
 };
 
-function fetchQueueLyrics(queueObject, event) {
+function fetchQueueLyrics(queueObject) {
     var songIndex = event.target.getAttribute('id');
     if (songIndex != null) {
         songIndex = Number(songIndex);
@@ -280,7 +278,7 @@ songList.on("click", 'article', () => { fetchLyrics(lyricsArray) });
 songList.on('click', '#return', () => { fetchSongs(userSearch) });
 recentListEl.on('click', '.recent', () => { fetchRecentLyrics(recentObject) });
 renderRecentList();
-queueListEl.on('click', '.queue', () => { fetchQueueLyrics(recentObject) });
+queueListEl.on('click', '.queue', () => { fetchQueueLyrics(queueObject) });
 renderQueueList();
 songList.on('click', 'i', () => { displayQueue(songData) });
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -7,7 +7,7 @@ var lyricsArray = [];
 
 userInputEl.on('change', getUserInput);
 
-function getUserInput () {
+function getUserInput() {
     userSearch = userInputEl.val().trim();
     userSearch = encodeURI(userSearch);
     userInputEl.val("");
@@ -21,7 +21,6 @@ function fetchSongs(userSearch) {
         .then(function (response) {
             if (response.ok) {
                 response.json().then(function (data) {
-                    console.log(data);
                     displaySongs(data);
                 });
             }
@@ -103,28 +102,31 @@ function displaySongs(data) {
 }
 
 
-songList.on("click", () => { fetchLyrics(lyricsArray) });
+songList.on("click", 'article', () => { fetchLyrics(lyricsArray) });
 
 
 function fetchLyrics(lyricsArray) {
-    var songIndex = event.target.getAttribute('id'); 
-    songIndex = Number(songIndex);
-    var lyricsAPI = lyricsArray[songIndex];
-    
-    fetch(lyricsAPI)
-        .then(function (response) {
-            if (response.ok) {
-                response.json().then(function (data) {
-                    console.log(data);
-                    displayLyrics(data);
-                });
-            }
-        })
+    var songIndex = event.target.getAttribute('id');
+    if (songIndex != null) {
+        songIndex = Number(songIndex);
+        var lyricsAPI = lyricsArray[songIndex];
+
+        fetch(lyricsAPI)
+            .then(function (response) {
+                if (response.ok) {
+                    response.json().then(function (data) {
+                        displayLyrics(data);
+                    });
+                }
+            })
+    }
 };
 
 function displayLyrics(data) {
     songList.empty();
 
+    var backBtn = $('<button id="return">');
+    backBtn.text('Return to search')
     var songP = $('<p>');
     var songHeaderEl = $('<strong>');
     var br = $('<br>');
@@ -132,7 +134,8 @@ function displayLyrics(data) {
     songP.append(songHeaderEl);
     songP.append(br);
     songP.append(songInfoEl);
-    songList.append(songP)
+    songList.append(backBtn);
+    songList.append(songP);
 
     var lyricsP = $('<p>');
     lyricsP.css("white-space", "pre-line");
@@ -148,3 +151,5 @@ function displayLyrics(data) {
     songInfoEl.text(artist + ", " + album);
     lyricsP.text(lyrics);
 };
+
+songList.on('click', '#return', () => { fetchSongs(userSearch) })

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -15,9 +15,6 @@ var recentCount = 0;
 
 var lyricsAPI = "";
 
-
-console.log(recentObject);
-
 userInputEl.on('change', getUserInput);
 
 function getUserInput() {
@@ -28,7 +25,6 @@ function getUserInput() {
 };
 
 function fetchSongs(userSearch) {
-    console.log(userSearch)
     var songAPI = "https://api.happi.dev/v1/music?q=" + userSearch + "&limit=20&type=:type&lyrics=1&" + apiKeyLyrics
 
     fetch(songAPI)


### PR DESCRIPTION
adds Return to Search button onto lyrics page

adds functions to 

1. add songs to the recent list when a user views their lyrics,
2. render the recent list upon refresh from info stored in localStorage,
3. allow a user to see the lyrics page of a song on the recent list by clicking on it
4. add songs to the queue list when a user clicks the heart icon, 
5. render the queue list upon refresh from info stored in localStorage, &
6. allow a user to see the lyrics page of a song on the queue list by clicking on it

Need to address bubbling effect that causes lyrics to be shown after clicking on the heart icon, and sometimes add song to recent list as well when clicking on heart icon